### PR TITLE
Improve Strategic section mobile layout

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,9 +3,18 @@
   --accent-color: #4cbbdb;
   --secondary-color: #66F0D1;
   --text-color: #02113a;
+  --light-bg: #ecfdf5; /* unified light background */
+}
+
+/* Global box-sizing and body reset to avoid overflow */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
 }
 
 body {
+  margin: 0;
   font-family: 'Inter', sans-serif;
 }
 
@@ -19,7 +28,7 @@ h1, h2, h3, h4, h5, h6, .hero-title, .projects-title, .services-title, .contact-
   justify-content: space-between;
   align-items: center;
   padding: 4rem 2rem;
-  background-color: #ffffff;
+  background-color: var(--light-bg);
   color: var(--text-color);
   flex-wrap: wrap;
 }
@@ -112,7 +121,7 @@ h1, h2, h3, h4, h5, h6, .hero-title, .projects-title, .services-title, .contact-
   justify-content: space-between;
   align-items: center;
   padding: 5rem 4rem;
-  background-color: #ecfdf5; /* tono verde menta suave */
+  background-color: var(--light-bg);
   flex-wrap: wrap;
   gap: 2rem;
 }
@@ -397,7 +406,7 @@ h1, h2, h3, h4, h5, h6, .hero-title, .projects-title, .services-title, .contact-
 /* === CONTACT FORM === */
 .contact-section {
   padding: 5rem 2rem;
-  background-color: #f1f5f9;
+  background-color: var(--light-bg);
   text-align: center;
 }
 .contact-title {
@@ -538,6 +547,20 @@ h1, h2, h3, h4, h5, h6, .hero-title, .projects-title, .services-title, .contact-
     padding: 2rem 1.5rem;
   }
 
+  .strategic {
+    flex-direction: column;
+    text-align: center;
+    padding: 3rem 2rem;
+  }
+
+  .strategic-left {
+    align-items: center;
+  }
+
+  .strategic-mockup {
+    max-width: 80%;
+  }
+
   .hero-left {
     align-items: center;
   }
@@ -573,6 +596,18 @@ h1, h2, h3, h4, h5, h6, .hero-title, .projects-title, .services-title, .contact-
   .hero {
     padding: 2rem 1rem;
     flex-direction: column;
+  }
+
+  .strategic {
+    padding: 2.5rem 1.5rem;
+  }
+
+  .strategic-title {
+    font-size: 1.8rem;
+  }
+
+  .strategic-mockup {
+    max-width: 90%;
   }
 
   .hero-left {
@@ -634,6 +669,18 @@ h1, h2, h3, h4, h5, h6, .hero-title, .projects-title, .services-title, .contact-
   .hero-photo {
     max-width: 300px;
 
+  }
+
+  .strategic-title {
+    font-size: 1.6rem;
+  }
+
+  .strategic-subtitle {
+    font-size: 1rem;
+  }
+
+  .strategic-mockup {
+    max-width: 100%;
   }
 
   .participation-card {

--- a/src/components/Strategic.tsx
+++ b/src/components/Strategic.tsx
@@ -10,7 +10,14 @@ export default function Strategic() {
         <p className="strategic-subtitle"> <b>Mi proyecto más destacado en mi vida profesional.</b>Iniciando con licencias de funcionamiento sin venta de alcohol, con capas de ortofotografía y vista de los predios, 
         por primera vez el Ayuntamiento de Cuernavaca cuenta con una plataforma de gestión de territorio y un trámite en línea de punta a punta.
         <b>¿Adaptamos la plataforma en tu ciudad?</b></p>
-        <a href="https://visorurbano.cuernavaca.gob.mx/inicio" className="strategic-button">Conoce este proyecto</a>
+        <a
+          href="https://visorurbano.cuernavaca.gob.mx/inicio"
+          className="strategic-button"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Conoce este proyecto
+        </a>
       </div>
       <div className="strategic-right">
         <Image


### PR DESCRIPTION
## Summary
- set global `box-sizing` and remove body margin
- add `--light-bg` variable for consistent light backgrounds
- switch Hero, Strategic and Contact sections to use the same light background

## Testing
- `npm run lint`
