### PR TITLE
Improve desktop layout

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,6 +9,7 @@ body {
   font-family: 'Inter', sans-serif;
 }
 
+
 h1, h2, h3, h4, h5, h6, .hero-title, .projects-title, .services-title, .contact-title {
   font-family: 'Poppins', sans-serif;
 }
@@ -117,8 +118,9 @@ font-size: clamp(1.5rem, 4vw, 2.5rem);
   background-color: #ecfdf5; /* tono verde menta suave */
   flex-wrap: wrap;
   gap: 2rem;
-    overflow-x: hidden; /* ✅ evita scroll horizontal */
-
+  overflow-x: hidden; /* ✅ evita scroll horizontal */
+  max-width: 1200px;
+  margin: 0 auto;
 }
 
 .strategic-left {
@@ -242,8 +244,10 @@ font-size: clamp(1.5rem, 4vw, 2.5rem);
 .participations-grid {
   display: grid;
   gap: 2rem;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
   justify-content: center;
+  max-width: 1200px;
+  margin: 0 auto;
 }
 
 .participation-card {
@@ -259,7 +263,7 @@ font-size: clamp(1.5rem, 4vw, 2.5rem);
 }
 
 .participation-img {
-    max-height: 220px;
+  height: 220px;
   object-fit: cover;
   width: 100%;
 }
@@ -325,8 +329,10 @@ font-size: clamp(1.5rem, 4vw, 2.5rem);
 .projects-grid {
   display: grid;
   gap: 2rem;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
   justify-content: center;
+  max-width: 1200px;
+  margin: 0 auto;
 }
 
 .project-card {
@@ -375,6 +381,8 @@ font-size: clamp(1.5rem, 4vw, 2.5rem);
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 2rem;
   justify-content: center;
+  max-width: 1200px;
+  margin: 0 auto;
 }
 
 .service-card {
@@ -506,6 +514,8 @@ font-size: clamp(1.5rem, 4vw, 2.5rem);
   align-items: stretch;
   gap: 2rem;
   flex-wrap: wrap;
+  max-width: 1200px;
+  margin: 0 auto;
 }
 
 .opensource-card {


### PR DESCRIPTION
## Summary
- limit strategic section width for large screens
- center participations, projects, services and open source grids
- keep images visible in highlighted participations

## Testing
- `npm run lint`
- `npm run build` *(fails: connect EHOSTUNREACH 172.20.0.3:8080)*

------
https://chatgpt.com/codex/tasks/task_b_683ddb26fb7883328a61960806a19554